### PR TITLE
Added check for deprecated function

### DIFF
--- a/src/MerchantWebService.php
+++ b/src/MerchantWebService.php
@@ -220,7 +220,13 @@ class MerchantWebService extends \SoapClient
             }
         }
         $options['location'] = 'https://wallet.advcash.com/wsm/merchantWebService';
-        libxml_disable_entity_loader(false);
+        if (LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader(false);
+        } else {
+            libxml_set_external_entity_loader(static function ($public, $system, $context) {
+                return false;
+            });
+        }
         parent::__construct($wsdl, $options);
     }
 


### PR DESCRIPTION
Newer versions of libxml (2.9.0 and above) use the new libxml_set_external_entity_loader() function to control the loading of external entities.